### PR TITLE
docs: add setup and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
-# Here are your Instructions
+# Marker Web
 
-## Setup
+## Project Structure
+- `backend/` – FastAPI application providing the API.
+- `frontend/` – React application built with Tailwind CSS.
+- `tests/` – automated tests (currently empty placeholder).
 
-1. Copy `backend/.env.example` to `backend/.env`.
-2. Fill in the environment variable values before running the backend.
+## Requirements
+- **Python** 3.11+
+- **Node.js** 18+ with **Yarn**
+- **MongoDB** 6+
+
+## Backend Setup
+1. Copy `backend/.env.example` to `backend/.env` and fill in the variables.
+2. Create a virtual environment and install dependencies:
+   ```bash
+   cd backend
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Run the development server:
+   ```bash
+   uvicorn backend.server:app --reload
+   ```
+
+## Frontend Setup
+1. Install dependencies:
+   ```bash
+   cd frontend
+   yarn install
+   ```
+2. Build production assets:
+   ```bash
+   yarn build
+   ```
+
+## Deployment
+1. Ensure the host has Python, Node.js, and MongoDB installed.
+2. Configure `backend/.env` with the production MongoDB connection and other settings.
+3. Build the frontend with `yarn build` and serve the `frontend/build` directory via a static file server or CDN.
+4. Run the backend with a process manager or container, e.g.:
+   ```bash
+   uvicorn backend.server:app --host 0.0.0.0 --port 8000
+   ```
+5. Configure reverse proxy (e.g., Nginx) to route API requests to the backend and serve the frontend build.


### PR DESCRIPTION
## Summary
- document project structure and environment requirements
- add backend and frontend setup steps with example commands
- outline deployment process for serving backend and built frontend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc1d9d2888332865a67f14555e329