### PR TITLE
feat: add server entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
    ```
 3. Run the development server:
    ```bash
+   python backend/server.py
+   # or
    uvicorn backend.server:app --reload
    ```
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -73,3 +73,13 @@ logger = logging.getLogger(__name__)
 @app.on_event("shutdown")
 async def shutdown_db_client():
     client.close()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "backend.server:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", 8000)),
+    )


### PR DESCRIPTION
## Summary
- allow running FastAPI server directly via `python backend/server.py`
- document both `python backend/server.py` and `uvicorn` commands for development server

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc36382308332ad7b6c588c096c1f