### PR TITLE
Add Docker configuration for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@
    yarn build
    ```
 
+## Docker Compose
+1. Build and start all services:
+   ```bash
+   docker-compose up --build
+   ```
+   - Backend API: http://localhost:8000
+   - Frontend UI: http://localhost:3000
+   - MongoDB: mongodb://localhost:27017 (data stored in `mongo-data` volume)
+2. Stop the containers:
+   ```bash
+   docker-compose down
+   ```
+
 ## Deployment
 1. Ensure the host has Python, Node.js, and MongoDB installed.
 2. Configure `backend/.env` with the production MongoDB connection and other settings.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.9'
+
+services:
+  mongo:
+    image: mongo:6
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  backend:
+    build: ./backend
+    environment:
+      MONGO_URL: mongodb://mongo:27017
+      DB_NAME: app
+      CORS_ORIGINS: "*"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mongo
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+
+volumes:
+  mongo-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+RUN yarn build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- containerize FastAPI backend with Uvicorn
- containerize React frontend and serve static build via Nginx
- orchestrate backend, frontend, and MongoDB with docker-compose
- document container workflow in README

## Testing
- `pytest`
- `cd frontend && CI=true yarn test --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689dc5bca3248332a7e0fdcd34cab5a0