### PR TITLE
docs: document frontend setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,70 +1,35 @@
-# Getting Started with Create React App
+# Marker Web Frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+React interface for the Marker project.
 
-## Available Scripts
+## Backend API Dependency
 
-In the project directory, you can run:
+The UI communicates with the FastAPI backend. Set the `REACT_APP_BACKEND_URL`
+environment variable to the base URL of the backend (e.g., `http://localhost:8000`).
+All API requests are made against `${REACT_APP_BACKEND_URL}/api`.
 
-### `npm start`
+## Environment Variables
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Create a `.env` file in this folder or define the variables in your shell.
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+- `REACT_APP_BACKEND_URL` – address of the backend API.
 
-### `npm test`
+## Development
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+```bash
+yarn install
+yarn start
+```
 
-### `npm run build`
+The app will be available on http://localhost:3000/.
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+## Building and Deployment
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+yarn build
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+The production files are generated in the `build` directory. Serve this directory with any
+static file server and make sure `REACT_APP_BACKEND_URL` points to a running backend.
 
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+For details on the overall project structure and backend setup, see the [repository README](../README.md).


### PR DESCRIPTION
## Summary
- replace Create React App template in frontend README
- document backend API dependency and environment variable
- add development, build, and deployment instructions with link to project README

## Testing
- `cd frontend && CI=true yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689dccd251608332b9e4a91b1d31eaf3